### PR TITLE
Closes #3 Chore: force import type and export type declaration for TS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,8 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/consistent-type-exports': 'error',
     'react/self-closing-comp': [
       'error',
       {

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  // This needs to be a function so that lint-staged does not pass any file arguments to the check-types script
+  // which would make it fail
+  '*.{ts,tsx}': () => 'yarn tsc -p tsconfig.json',
+  '*.{js,jsx,ts,tsx}': 'yarn lint',
+  // 'styles.ts': 'stylelint --fix',
+  '*.{js,jsx,ts,tsx,html,md,json,yml}': 'prettier --write',
+};


### PR DESCRIPTION
Esta PR incluye nuevas reglas de eslint que mantienen consistente la importación y exportación de tipos de TS cuando sólo se importa un tipo.

Explicación detallada en este artículo: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/#isolated-module-transpilation 

También se ha agregado un archivo pendiente de configuración para lint stage, proceso detonado al realizar cualquier commit.